### PR TITLE
Add Next.js project for Claude ebook site

### DIFF
--- a/claude-ebook-site/package.json
+++ b/claude-ebook-site/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "claude-ebook-site",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/claude-ebook-site/pages/_app.js
+++ b/claude-ebook-site/pages/_app.js
@@ -1,0 +1,14 @@
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <main style={{
+      fontFamily: 'sans-serif',
+      maxWidth: 800,
+      margin: '0 auto',
+      padding: 24,
+      background: '#fff',
+      minHeight: '100vh'
+    }}>
+      <Component {...pageProps} />
+    </main>
+  );
+}

--- a/claude-ebook-site/pages/index.js
+++ b/claude-ebook-site/pages/index.js
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <>
+      <h1>Guia Completo do Claude</h1>
+      <p style={{fontSize: 18, marginBottom: 32}}>Leitura fácil no celular. Use o menu para acessar os capítulos.</p>
+      <h2>Índice</h2>
+      <ul style={{fontSize:18, lineHeight:2}}>
+        <li><Link href="/01-introducao">Introdução</Link></li>
+        <li><Link href="/02-primeiros-passos">Parte 1: Primeiros Passos</Link></li>
+        <li><Link href="/03-visao-detalhada">Parte 2: Visão Detalhada dos Recursos</Link></li>
+        <li><Link href="/04-aplicacoes">Parte 3: Aplicações Práticas</Link></li>
+        <li><Link href="/05-implementacao">Parte 4: Implementação Avançada</Link></li>
+        <li><Link href="/06-conclusao">Conclusão</Link></li>
+      </ul>
+      <footer style={{marginTop:32, fontSize:12, color:'#888'}}>© {new Date().getFullYear()} Guia Claude – Adaptado para web</footer>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project `claude-ebook-site`
- add basic `_app.js` layout
- add index page with chapter links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687127ac0be883299c0ebe0bbca415e1